### PR TITLE
update config

### DIFF
--- a/dlp-waf/proxy.yaml
+++ b/dlp-waf/proxy.yaml
@@ -16,7 +16,17 @@ spec:
         enabledFor: ALL
         dlpRules:
           - actions:
-            - keyValueAction:
+            - actionType: CUSTOM # CUSTOM is the default, so it's not necessary to put the actionType here
+              customAction:
+                name: api-key
+                maskChar: "X"
+                percent:
+                  value: 25
+                regexActions:
+                  - regex: api-key:? *([^\\n]*)(?:\\n)
+                    subgroup: 1
+            - actionType: KEYVALUE
+              keyValueAction:
                 keyToMask: api-key
                 maskChar: "*"
                 name: api-key   # only used for logging


### PR DESCRIPTION
working to match the regex for api-key in body and match the header api-key

takeaways:
- `actionType: KEYVALUE` is required for `keyValueAction`s
- `keyValueAction`s cannot modify response bodies, so a `customAction` with a regex is still required there